### PR TITLE
Improve Teams Webhook support

### DIFF
--- a/autopkg-conductor.sh
+++ b/autopkg-conductor.sh
@@ -129,13 +129,17 @@ done
 
 }
 
-# Function for sending multi-line output to a Teams webhook.
+# Function for sending multi-line output to a Teams webhook. We add an extra Return to
+# each line of the log file ($1) to prevent Teams from showing the log on a single line.
+# The Teams Card format requires JSON to be sent to the Teams webhook ($2).
+# You can add a title to the Card by specifying it as a third argument.
+
 
 SendToTeams(){
 
-while read LINE; do
-  (echo "${LINE}" | grep -e "$3") && curl -X POST -H 'Content-Type: application/json' --silent -d "{\"text\": \"${LINE//\"/\'/}\"}" "$2";
-done < "$1"
+LOG_TEXT=$( cat "$1" | sed "s/\"/'/g" | sed "s/$/\r\r/g" )
+TEAMS_JSON="{\"title\": \"$3\", \"text\": \"${LOG_TEXT}\" }"
+curl -H "Content-Type: application/json" -d "${TEAMS_JSON}" "$2"
 
 }
 
@@ -199,7 +203,7 @@ if [[ ! -r "$recipe_list" ]]; then
     # If a Teams webhook is configured, send the error log to Teams.
     
     if [[ ! -z "$teams_webhook" ]]; then
-        SendToTeams /tmp/autopkg_error.out ${teams_webhook}
+        SendToTeams /tmp/autopkg_error.out ${teams_webhook} "AutoPkg-Conductor Configuration Error"
     fi
     
     cat /tmp/autopkg_error.out >> "$log_location"
@@ -316,7 +320,7 @@ if [[ -x /usr/local/bin/autopkg ]] && [[ -r "$recipe_list" ]]; then
        # all standard output should be sent to Teams.
        
        ScriptLogging "Sending AutoPkg output log to Teams"
-       SendToTeams /tmp/autopkg.out ${teams_webhook}
+       SendToTeams /tmp/autopkg.out ${teams_webhook} "AutoPkg-Conductor Run $(date +%Y-%m-%d\ %H:%M:%S)"
        ScriptLogging "Sent AutoPkg output log to $teams_webhook."
     
     fi
@@ -345,7 +349,7 @@ if [[ -x /usr/local/bin/autopkg ]] && [[ -r "$recipe_list" ]]; then
     
        if [[ $(wc -l </tmp/autopkg_error.out) -gt 7 ]]; then
            ScriptLogging "Sending AutoPkg error log to Teams"
-           SendToTeams /tmp/autopkg_error.out ${teams_webhook}
+           SendToTeams /tmp/autopkg_error.out ${teams_webhook} "AutoPkg-Conductor Error Log"
            ScriptLogging "Sent autopkg log to $teams_webhook. Ending run."
        else
            ScriptLogging "Error log was empty. Nothing to send to Teams."

--- a/autopkg-conductor.sh
+++ b/autopkg-conductor.sh
@@ -196,6 +196,12 @@ if [[ ! -r "$recipe_list" ]]; then
         SendToSlack /tmp/autopkg_error.out ${slack_webhook}
     fi
     
+    # If a Teams webhook is configured, send the error log to Teams.
+    
+    if [[ ! -z "$teams_webhook" ]]; then
+        SendToTeams /tmp/autopkg_error.out ${teams_webhook}
+    fi
+    
     cat /tmp/autopkg_error.out >> "$log_location"
     ScriptLogging "Finished AutoPkg run"
     exit_error=1


### PR DESCRIPTION
This PR consists of two separate commits, in case you do not wish to adopt both changes.

1. "[Add Teams error report if recipe list missing](https://github.com/rtrouton/autopkg-conductor/commit/ef0800bca30e432badd1905b70c3e935d932cfff)" adds an error report to Teams that was previously only being sent to Slack.
2. In my testing, SendToTeams sends one message per line when using a webhook (e.g., a 3-line error log would be sent one line at a time, generating three Teams cards/messages). In [Change SendToTeams to support multi-line cards](https://github.com/rtrouton/autopkg-conductor/commit/e5d389f6ec1ea0c4e220e2c647f84bb4e81756c7), I have completely replaced the SendToTeams subroutine with one that changes the text into a format that is more friendly for the Teams Card format. As a bonus, I have added support for the title function and created default titles.

As an example, running a 1-recipe list with three repos, a configured webhook, and no post-processor generates the following output in Teams using the existing script:
<img width="836" alt="OldCode-1" src="https://github.com/rtrouton/autopkg-conductor/assets/4193278/9999957b-b047-459f-9149-7c8adc068206">
<img width="831" alt="OldCode-2" src="https://github.com/rtrouton/autopkg-conductor/assets/4193278/3fdf8e14-a4ea-4f90-b12e-a1f1f1c83688">
<img width="833" alt="OldCode-3" src="https://github.com/rtrouton/autopkg-conductor/assets/4193278/7645a8c6-9537-4ac5-819c-8a63321c59ff">

With the script modified as per this PR, the following output is seen in Teams:
<img width="836" alt="NewCode" src="https://github.com/rtrouton/autopkg-conductor/assets/4193278/6f919956-451a-49aa-876f-74bcd025096d">
